### PR TITLE
GET_Projects response objects type

### DIFF
--- a/endpoints/project/GET_projects.md
+++ b/endpoints/project/GET_projects.md
@@ -22,8 +22,8 @@ Retrieve all projects of specified platform
 **Response**
 ``` json
 {
-    "projects": [
-        {
+    "projects": {
+		"0": {
             "id": 8356,
             "name": "Sportswear",
             "platform": "Magento",
@@ -33,9 +33,9 @@ Retrieve all projects of specified platform
                 "local_name": "English (United States)",
                 "locale": "en",
                 "region" : "US"
-            }
+        	}
         },
-        {
+        "1": {
             "id": 8357,
             "name": "Jeans",
             "platform": "Magento",

--- a/endpoints/project/GET_projects.md
+++ b/endpoints/project/GET_projects.md
@@ -23,7 +23,7 @@ Retrieve all projects of specified platform
 ``` json
 {
     "projects": {
-		"0": {
+        "0": {
             "id": 8356,
             "name": "Sportswear",
             "platform": "Magento",
@@ -33,7 +33,7 @@ Retrieve all projects of specified platform
                 "local_name": "English (United States)",
                 "locale": "en",
                 "region" : "US"
-        	}
+            }
         },
         "1": {
             "id": 8357,


### PR DESCRIPTION
JSON Type of response is not an array (`[ ... ]`) but an object or dictionary (`{ ... }`).
I guess it's extremely important to have proper response type in documentation (ran into several problems myself).

PS. For my taste it would be better to fix API itself to response with actual JSON array.