### PR TITLE
Fix for 'GET Language Pairs' response.

### DIFF
--- a/endpoints/language_pair/GET_language_pairs.md
+++ b/endpoints/language_pair/GET_language_pairs.md
@@ -22,7 +22,11 @@ Returns order supported language pairs
 **Response**
 ``` json
 {
-    "locales": [
+    "meta": {
+        "status": 200,
+        "record_count": 451
+    },    
+    "data": [
         {
             "code": "en-US",
             "english_name": "English (United States)",


### PR DESCRIPTION
Now 'GET Language Pairs' response contains `meta` and `data` fields (as **Platform** endpoints do).
So, documentation should be updated to cover that (or API ahould be fixed to return data in previous format).
